### PR TITLE
Prepare for publication to prod

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -11,4 +11,4 @@ topics:
     - title: JavaScript
       src: js/README.md
     - title: Python
-      src: python/style.rst
+      src: python/style.md

--- a/python/style.md
+++ b/python/style.md
@@ -1,0 +1,6 @@
+Workiva Python Style Guide
+--------------------------
+
+In true Python fashion, these docs are written in rst. Until rst docs support
+has been released to prod, please visit the GitHub page hosting this document
+[here](https://github.com/Workiva/styleguide/blob/master/python/style.rst)


### PR DESCRIPTION
@macleodbroad-wf 

This is a temporary placeholder for python documentation until we get rst support deployed to prod. Since the conversion pipeline is implemented with lambda, our initial deployment hasn't been as straightforward as we've hoped, but is a high priority item we expect to have completed in the next couple of weeks.

Once this is merged, we can publish to dev.inf.workiva.net